### PR TITLE
Updating method_whitelist to allowed_methods

### DIFF
--- a/sumo_handler/__init__.py
+++ b/sumo_handler/__init__.py
@@ -116,7 +116,7 @@ class SumoHandler(logging.Handler):
         self.write_debug_log("Preparing to create a Requests session")
         retry = Retry(total=self.retry_count,
                       backoff_factor=self.retry_backoff,
-                      method_whitelist=False,  # Retry for any HTTP verb
+                      allowed_methods=False,  # Retry for any HTTP verb
                       status_forcelist=[500, 502, 503, 504])
         self.session.mount('https://', HTTPAdapter(max_retries=retry))
 


### PR DESCRIPTION
This PR updates the deprecated retry config method_whitelist to allowed_methods. This is related to the library update: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html